### PR TITLE
fix: Add Offline steps to install WAF compiler on NIM

### DIFF
--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -206,11 +206,12 @@ error when creating the nginx repo retriever - NGINX repo certificates not found
 
 Also, please refer to [Install the WAF Compiler](#install-the-waf-compiler) for details on how to manually install the new WAF compiler.
 
-## Installing WAF compiler in Disconnected environments
+## Install the WAF compiler in a disconnected environment
 
-This involves below two steps 
-Step-1. Generating the WAF compiler package on the system which has internet access
-Step-2. Moving the generated package to the target system ( which do not have internet access) and installing the compiler package
+To install the WAF compiler on a system without internet access, complete these steps:
+
+- **Step 1:** Generate the WAF compiler package on a system that has internet access.  
+- **Step 2:** Move the generated package to the offline target system and install it.
 
 {{<tabs name="WAF compiler installation in offline environment">}}
 

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -212,37 +212,11 @@ This involves below two steps
 Step-1. Generating the WAF compiler package on the system which has internet access
 Step-2. Moving the generated package to the target system ( which do not have internet access) and installing the compiler package
 
-### Steps for RHEL based systems ( RHEL8 and RHEL9)
+{{<tabs name="WAF compiler installation in offline environment">}}
 
-Step-1 : ( To be performed on system with Internet access)
+{{%tab name="Ubuntu"%}}
 
-Place your nginx-repo.crt and nginx-repo.key files in this machine.
-```bash
-sudo yum update -y
-sudo yum install yum-utils -y
-sudo mkdir -p /etc/ssl/nginx/
-sudo mv nginx-repo.crt /etc/ssl/nginx/
-sudo mv nginx-repo.key /etc/ssl/nginx/
-sudo wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nms.repo
-sudo yum-config-manager --disable rhel-9-appstream-rhui-rpms
-sudo yum update -y
-sudo mkdir -p nms-nap-compiler
-sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.342.0
-tar -czvf compiler.tar.gz nms-nap-compiler/
-```
-
-Step-2 : ( On target system)
-
-Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
-Move the compiler.tar.gz file generated in the previous step to this target system.
-
-```bash
-tar -xzvf compiler.tar.gz
-cd nms-nap-compiler
-sudo dnf install *.rpm --disablerepo=*
-```
-
-### Steps for Ubuntu systems ( Ubuntu-22.04 & Ubuntu-24.04)
+### Install WAF compiler on Ubuntu-24.04, Ubuntu-22.04 and Ubuntu-20.04 systems
 
 Step-1 : ( To be performed on system with Internet access)
 
@@ -281,6 +255,133 @@ tar -xzvf compiler.tar.gz
 sudo dpkg -i ./compiler/compiler.deps/*.deb
 sudo dpkg -i ./compiler/*.deb
 ```
+
+{{%/tab%}}
+
+{{%tab name="Debian"%}}
+
+### Install WAF compiler on Debian-11 and Debian-12 systems
+
+Step-1 : ( To be performed on system with Internet access)
+
+Place your nginx-repo.crt and nginx-repo.key files in this machine.
+```bash
+sudo apt-get update -y
+sudo mkdir -p /etc/ssl/nginx/
+sudo mv nginx-repo.crt /etc/ssl/nginx/
+sudo mv nginx-repo.key /etc/ssl/nginx/
+
+wget -qO - https://cs.nginx.com/static/keys/nginx_signing.key \
+    | gpg --dearmor \
+    | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+
+printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+https://pkgs.nginx.com/nms/debian $(lsb_release -cs) nginx-plus\n" | \
+sudo tee /etc/apt/sources.list.d/nms.list
+
+sudo wget -q -O /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx
+mkdir -p compiler && cd compiler
+sudo apt-get update
+sudo apt-get download nms-nap-compiler-v5.342.0
+cd ../
+mkdir -p compiler/compiler.deps
+sudo apt-get install --download-only --reinstall --yes --print-uris nms-nap-compiler-v5.342.0 | grep ^\' | cut -d\' -f2 | xargs -n 1 wget -P ./compiler/compiler.deps
+tar -czvf compiler.tar.gz compiler/
+```
+
+Step-2 : ( On target system)
+
+Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
+Move the compiler.tar.gz file generated in the previous step to this target system.
+
+```bash
+tar -xzvf compiler.tar.gz
+sudo dpkg -i ./compiler/compiler.deps/*.deb
+sudo dpkg -i ./compiler/*.deb
+```
+
+{{%/tab%}}
+
+{{%tab name="RHEL8, RHEL9, Oracle-9 "%}}
+
+###  Install WAF compiler on RHEL-8 and RHEL-9 systems
+
+Step-1 : ( To be performed on system with Internet access)
+
+Note: For Rhel-8, we can omit the line 'sudo yum-config-manager ....'
+
+Place your nginx-repo.crt and nginx-repo.key files in this machine.
+```bash
+sudo yum update -y
+sudo yum install yum-utils -y
+sudo mkdir -p /etc/ssl/nginx/
+sudo mv nginx-repo.crt /etc/ssl/nginx/
+sudo mv nginx-repo.key /etc/ssl/nginx/
+sudo wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nms.repo
+sudo yum-config-manager --disable rhel-9-appstream-rhui-rpms
+sudo yum update -y
+sudo mkdir -p nms-nap-compiler
+sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.342.0
+tar -czvf compiler.tar.gz nms-nap-compiler/
+```
+
+Step-2 : ( On target system)
+
+Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
+Move the compiler.tar.gz file generated in the previous step to this target system.
+
+```bash
+tar -xzvf compiler.tar.gz
+cd nms-nap-compiler
+sudo dnf install *.rpm --disablerepo=*
+```
+
+{{%/tab%}}
+
+{{%tab name="Oracle-8"%}}
+
+###  Install WAF compiler on Oracle-8 system
+
+Place your nginx-repo.crt and nginx-repo.key files in this machine.
+```bash
+sudo yum update -y
+sudo yum install yum-utils tar -y
+sudo mkdir -p /etc/ssl/nginx/
+sudo mv nginx-repo.crt /etc/ssl/nginx/
+sudo mv nginx-repo.key /etc/ssl/nginx/
+sudo wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nms.repo
+
+sudo tee /etc/yum.repos.d/centos-vault-powertools.repo << 'EOF'
+[centos-vault-powertools]
+name=CentOS Vault - PowerTools
+baseurl=https://vault.centos.org/centos/8/PowerTools/x86_64/os/
+enabled=1
+gpgcheck=0
+EOF
+
+sudo yum update -y
+sudo mkdir -p nms-nap-compiler
+sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.342.0
+tar -czvf compiler.tar.gz nms-nap-compiler/
+```
+
+Step-2 : ( On target system)
+
+Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
+Move the compiler.tar.gz file generated in the previous step to this target system.
+
+```bash
+sudo yum install tar -y
+tar -xzvf compiler.tar.gz
+sudo dnf install --disablerepo=* nms-nap-compiler/*.rpm
+```
+
+
+{{%/tab%}}
+
+
+{{</tabs>}}
+
 ---
 
 ## Set Up Attack Signatures and Threat Campaigns

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -368,10 +368,10 @@ sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.342.
 tar -czvf compiler.tar.gz nms-nap-compiler/
 ```
 
-Step-2 : ( On target system)
+#### Step 2: On the target (offline) system
 
-Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
-Move the compiler.tar.gz file generated in the previous step to this target system.
+Before running the steps, make sure the OS libraries are up to date, especially `glibc`.  
+Move the `compiler.tar.gz` file from Step 1 to this system.
 
 ```bash
 sudo yum install tar -y

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -246,10 +246,10 @@ sudo apt-get install --download-only --reinstall --yes --print-uris nms-nap-comp
 tar -czvf compiler.tar.gz compiler/
 ```
 
-Step-2 : ( On target system)
+#### Step 2: On the target (offline) system
 
-Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
-Move the compiler.tar.gz file generated in the previous step to this target system.
+Before running the steps, make sure the OS libraries are up to date, especially `glibc`.  
+Move the `compiler.tar.gz` file from Step 1 to this system.
 
 ```bash
 tar -xzvf compiler.tar.gz

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -290,10 +290,10 @@ sudo apt-get install --download-only --reinstall --yes --print-uris nms-nap-comp
 tar -czvf compiler.tar.gz compiler/
 ```
 
-Step-2 : ( On target system)
+#### Step 2: On the target (offline) system
 
-Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
-Move the compiler.tar.gz file generated in the previous step to this target system.
+Before running the steps, make sure the OS libraries are up to date, especially `glibc`.  
+Move the `compiler.tar.gz` file from Step 1 to this system.
 
 ```bash
 tar -xzvf compiler.tar.gz

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -305,13 +305,13 @@ sudo dpkg -i ./compiler/*.deb
 
 {{%tab name="RHEL8, RHEL9, Oracle-9 "%}}
 
-###  Install WAF compiler on RHEL-8 and RHEL-9 systems
+### Install on RHEL 8, RHEL 9, or Oracle Linux 9
 
-Step-1 : ( To be performed on system with Internet access)
+#### Step 1: On a system with internet access
 
-Note: For Rhel-8, we can omit the line 'sudo yum-config-manager ....'
+> For RHEL 8, you can skip the `yum-config-manager` line.
 
-Place your nginx-repo.crt and nginx-repo.key files in this machine.
+Place your `nginx-repo.crt` and `nginx-repo.key` files on this system.
 ```bash
 sudo yum update -y
 sudo yum install yum-utils -y

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -341,9 +341,11 @@ sudo dnf install *.rpm --disablerepo=*
 
 {{%tab name="Oracle-8"%}}
 
-###  Install WAF compiler on Oracle-8 system
+### Install on Oracle Linux 8
 
-Place your nginx-repo.crt and nginx-repo.key files in this machine.
+#### Step 1: On a system with internet access
+
+Place your `nginx-repo.crt` and `nginx-repo.key` files on this system.
 ```bash
 sudo yum update -y
 sudo yum install yum-utils tar -y

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -217,11 +217,11 @@ To install the WAF compiler on a system without internet access, complete these 
 
 {{%tab name="Ubuntu"%}}
 
-### Install WAF compiler on Ubuntu-24.04, Ubuntu-22.04 and Ubuntu-20.04 systems
+### Install on Ubuntu 24.04, 22.04, and 20.04
 
-Step-1 : ( To be performed on system with Internet access)
+#### Step 1: On a system with internet access
 
-Place your nginx-repo.crt and nginx-repo.key files in this machine.
+Place your `nginx-repo.crt` and `nginx-repo.key` files on this system.
 ```bash
 sudo apt-get update -y
 sudo mkdir -p /etc/ssl/nginx/

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -326,10 +326,10 @@ sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.342.
 tar -czvf compiler.tar.gz nms-nap-compiler/
 ```
 
-Step-2 : ( On target system)
+#### Step 2: On the target (offline) system
 
-Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
-Move the compiler.tar.gz file generated in the previous step to this target system.
+Before running the steps, make sure the OS libraries are up to date, especially `glibc`.  
+Move the `compiler.tar.gz` file from Step 1 to this system.
 
 ```bash
 tar -xzvf compiler.tar.gz

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -261,11 +261,11 @@ sudo dpkg -i ./compiler/*.deb
 
 {{%tab name="Debian"%}}
 
-### Install WAF compiler on Debian-11 and Debian-12 systems
+### Install on Debian 11 and 12
 
-Step-1 : ( To be performed on system with Internet access)
+#### Step 1: On a system with internet access
 
-Place your nginx-repo.crt and nginx-repo.key files in this machine.
+Place your `nginx-repo.crt` and `nginx-repo.key` files on this system.
 ```bash
 sudo apt-get update -y
 sudo mkdir -p /etc/ssl/nginx/

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -206,6 +206,81 @@ error when creating the nginx repo retriever - NGINX repo certificates not found
 
 Also, please refer to [Install the WAF Compiler](#install-the-waf-compiler) for details on how to manually install the new WAF compiler.
 
+## Installing WAF compiler in Disconnected environments
+
+This involves below two steps 
+Step-1. Generating the WAF compiler package on the system which has internet access
+Step-2. Moving the generated package to the target system ( which do not have internet access) and installing the compiler package
+
+### Steps for RHEL based systems ( RHEL8 and RHEL9)
+
+Step-1 : ( To be performed on system with Internet access)
+
+Place your nginx-repo.crt and nginx-repo.key files in this machine.
+```bash
+sudo yum update -y
+sudo yum install yum-utils -y
+sudo mkdir -p /etc/ssl/nginx/
+sudo mv nginx-repo.crt /etc/ssl/nginx/
+sudo mv nginx-repo.key /etc/ssl/nginx/
+sudo wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nms.repo
+sudo yum-config-manager --disable rhel-9-appstream-rhui-rpms
+sudo yum update -y
+sudo mkdir -p nms-nap-compiler
+sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.342.0
+tar -czvf compiler.tar.gz nms-nap-compiler/
+```
+
+Step-2 : ( On target system)
+
+Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
+Move the compiler.tar.gz file generated in the previous step to this target system.
+
+```bash
+tar -xzvf compiler.tar.gz
+cd nms-nap-compiler
+sudo dnf install *.rpm --disablerepo=*
+```
+
+### Steps for Ubuntu systems ( Ubuntu-22.04 & Ubuntu-24.04)
+
+Step-1 : ( To be performed on system with Internet access)
+
+Place your nginx-repo.crt and nginx-repo.key files in this machine.
+```bash
+sudo apt-get update -y
+sudo mkdir -p /etc/ssl/nginx/
+sudo mv nginx-repo.crt /etc/ssl/nginx/
+sudo mv nginx-repo.key /etc/ssl/nginx/
+
+wget -qO - https://cs.nginx.com/static/keys/nginx_signing.key \
+    | gpg --dearmor \
+    | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+
+printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+https://pkgs.nginx.com/nms/ubuntu $(lsb_release -cs) nginx-plus\n" | \
+sudo tee /etc/apt/sources.list.d/nms.list
+
+sudo wget -q -O /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx
+mkdir -p compiler && cd compiler
+sudo apt-get update
+sudo apt-get download nms-nap-compiler-v5.342.0
+cd ../
+mkdir -p compiler/compiler.deps
+sudo apt-get install --download-only --reinstall --yes --print-uris nms-nap-compiler-v5.342.0 | grep ^\' | cut -d\' -f2 | xargs -n 1 wget -P ./compiler/compiler.deps
+tar -czvf compiler.tar.gz compiler/
+```
+
+Step-2 : ( On target system)
+
+Prior to execution of below steps, make sure all the OS modules/libraries are updated ( especially glibc). 
+Move the compiler.tar.gz file generated in the previous step to this target system.
+
+```bash
+tar -xzvf compiler.tar.gz
+sudo dpkg -i ./compiler/compiler.deps/*.deb
+sudo dpkg -i ./compiler/*.deb
+```
 ---
 
 ## Set Up Attack Signatures and Threat Campaigns


### PR DESCRIPTION


Problem: Currently steps of install WAF compiler on disconnected environments is not documented. This PR tries to address it.

Solution: Tested the steps and documented them as part of this PR.

Testing:  Tested the steps  on Redhat-8, Redhat-9 , Ubuntu-24, Ubuntu-22, oracle-8, oracle-9, debian-11 and debian-12  systems.



Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have rebased my branch onto main
- [x] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [x] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured that existing tests pass after adding my changes
- [x] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.